### PR TITLE
Add portable exe build for PC server in GitHub Actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/pc-explorer-from-mobile/issues/8
-Your prepared branch: issue-8-f281a6c6b20d
-Your prepared working directory: /tmp/gh-issue-solver-1768710888249
-Your forked repository: konard/Jhon-Crow-pc-explorer-from-mobile
-Original repository (upstream): Jhon-Crow/pc-explorer-from-mobile
-
-Proceed.


### PR DESCRIPTION
## Summary
- Add a new GitHub Actions workflow (`pc-server.yml`) that builds a portable Windows executable from the Python PC server using PyInstaller
- The exe is uploaded as a build artifact (`pc-explorer-server-windows`) that can be downloaded from the Actions page

## Technical Details
- Uses `windows-latest` runner for native Windows exe compilation
- Python 3.11 with pip caching for faster builds
- PyInstaller with `--onefile` flag to create a single portable executable
- Includes all necessary modules (`protocol.py`, `file_handler.py`) in the bundle

## Test Plan
- [x] Verify workflow triggers on push/PR to main branch
- [x] Verify PyInstaller successfully builds the exe
- [x] Verify the exe artifact is uploaded
- [x] All CI checks pass

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)